### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/taihen/dns-benchmark/security/code-scanning/3](https://github.com/taihen/dns-benchmark/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any actions requiring write permissions, we can set the permissions to `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the least privilege necessary to function.

The changes will be made to the `.github/workflows/test.yml` file:
1. Add a `permissions` block at the root level of the workflow, specifying `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
