### PR TITLE
feat(config): removal of DNS4EU from default list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Visit [taihen.org](https://taihen.org) for introductory [announcement](https://t
 - **Metrics Measured:**
   - **Cached Latency:** Average and Standard Deviation for resolving likely cached domains.
   - **Uncached Latency:** Average and Standard Deviation for resolving unique, likely uncached domains.
-  - **Reliability:** Percentage of successful latency queries.
-  - **.com Latency:** Latency for resolving a unique `.com` domain (`-dotcom` flag).
+  - **Reliability:** Percentage of latency probes that returned a structurally valid DNS response. Unexpected DNS rcodes are reported separately as DNS failures.
+  - **.com Latency:** Latency for resolving a random `.com` NXDOMAIN lookup (`-dotcom` flag).
 - **Resolver Checks:**
   - **DNSSEC Validation:** Checks if the resolver validates DNSSEC signatures (`-dnssec` flag, default: false).
   - **NXDOMAIN Hijacking:** Detects if the resolver redirects non-existent domains (`-nxdomain` flag, default: false).
@@ -54,7 +54,7 @@ Visit [taihen.org](https://taihen.org) for introductory [announcement](https://t
   - Adjust number of queries (`-n`, default: 50), timeout (`-t`), concurrency (`-c`), and rate limit (`-rate`).
 - **Output:**
   - Formatted console table with results sorted by uncached latency.
-  - Console summary recommending the fastest reliable server and highlighting potential issues.
+  - Console summary recommending the fastest server with high response reliability, no latency-probe DNS failures, and confirmed accuracy when the accuracy check is enabled.
   - CSV output (`-format csv`).
   - JSON output (`-format json`).
   - Option to write output to a file (`-o <filename>`).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Visit [taihen.org](https://taihen.org) for introductory [announcement](https://t
   - **DNS Rebinding Protection:** Checks if the resolver blocks queries for domains resolving to private IPs (`-rebinding` flag, default: false).
   - **Response Accuracy:** Verifies if the resolver returns the expected IP for a known domain (requires `-accuracy-file` flag).
 - **Configuration:**
-  - Use built-in list of common public resolvers (Cloudflare, Google, Quad9, Adguard).
+  - Use a built-in list of common public resolvers from Cloudflare, Google, Quad9, OpenDNS, AdGuard, and DNS4EU.
   - Provide a custom list of servers via file (`-f <filename>`), including protocol prefixes.
   - Include system-configured DNS servers (UDP only) (`-system` flag, default: true unless `-f` is used).
   - Adjust number of queries (`-n`, default: 50), timeout (`-t`), concurrency (`-c`), and rate limit (`-rate`).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,6 +114,10 @@ var DefaultDNSStrings = []string{
 	"94.140.14.14",
 	"tls://dns.adguard-dns.com",
 	"https://dns.adguard-dns.com/dns-query",
+	// DNS4EU (Unfiltered)
+	"86.54.11.100",
+	"tls://unfiltered.joindns4.eu",
+	"https://unfiltered.joindns4.eu/dns-query",
 }
 
 // LoadConfig parses flags, reads files, and returns the final configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,16 +108,12 @@ var DefaultDNSStrings = []string{
 	"https://dns.quad9.net/dns-query",
 	// OpenDNS
 	"208.67.222.222",
-	"tls://dns.opendns.com", // Uses hostname
+	"tls://dns.opendns.com",
 	"https://doh.opendns.com/dns-query",
-	// AdGuard DNS (Default)
+	// AdGuard DNS
 	"94.140.14.14",
 	"tls://dns.adguard-dns.com",
 	"https://dns.adguard-dns.com/dns-query",
-	// DNS0.eu
-	"193.110.81.0",
-	"185.253.5.0",
-	"tls://dns0.eu",
 }
 
 // LoadConfig parses flags, reads files, and returns the final configuration.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -572,6 +572,20 @@ func TestDefaultDNSStringsDoesNotIncludeDNS0EU(t *testing.T) {
 	}
 }
 
+func TestDefaultDNSStringsIncludesDNS4EUUnfiltered(t *testing.T) {
+	required := []string{
+		"86.54.11.100",
+		"tls://unfiltered.joindns4.eu",
+		"https://unfiltered.joindns4.eu/dns-query",
+	}
+
+	for _, entry := range required {
+		if !slices.Contains(DefaultDNSStrings, entry) {
+			t.Fatalf("DefaultDNSStrings is missing expected entry %q", entry)
+		}
+	}
+}
+
 // Helper to sort ServerInfo slices for comparison.
 func sortServerInfos(infos []ServerInfo) {
 	sort.Slice(infos, func(i, j int) bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -554,6 +555,20 @@ func TestParseAndDeduplicateServers(t *testing.T) {
 				t.Errorf("parseAndDeduplicateServers() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultDNSStringsDoesNotIncludeDNS0EU(t *testing.T) {
+	disallowed := []string{
+		"193.110.81.0",
+		"185.253.5.0",
+		"tls://dns0.eu",
+	}
+
+	for _, entry := range disallowed {
+		if slices.Contains(DefaultDNSStrings, entry) {
+			t.Fatalf("DefaultDNSStrings contains deprecated entry %q", entry)
+		}
 	}
 }
 


### PR DESCRIPTION
Remove DNS0.eu from default resolver list as it [stopped operating](https://news.ycombinator.com/from?site=bleepingcomputer.com) and replaced it with DNS4EU.