### PR TITLE
chore(github): update Homebrew tap and installation instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,15 @@ jobs:
           cd ..
 
       - name: Semantic Release
+        id: semantic-release
         uses: cycjimmy/semantic-release-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Configuration is now handled by .releaserc.json
+
+      - name: Update Homebrew tap
+        if: ${{ steps.semantic-release.outputs.new_release_published == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.semantic-release.outputs.new_release_git_tag }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP }}
+        run: bash ./scripts/update-homebrew-formula.sh

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,12 +1,11 @@
-name: Update Homebrew Tap on Release
+name: Update Homebrew Tap
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag_name:
         description: 'Release tag to update (e.g., v1.4.0)'
         required: true
+        type: string
 permissions:
   contents: read
 jobs:
@@ -18,77 +17,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
-      - name: Compute tarball URL and SHA256
-        id: artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${{ github.event.release.tag_name || github.event.inputs.tag_name }}"
-          OWNER="${{ github.repository_owner }}"
-          REPO="${{ github.event.repository.name }}"
-          URL="https://github.com/${OWNER}/${REPO}/archive/refs/tags/${TAG}.tar.gz"
-          echo "url=${URL}" >> "$GITHUB_OUTPUT"
-          SHA256=$(curl -fsSL "$URL" | sha256sum | awk '{print $1}')
-          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
-          VERSION_TRIMMED="${TAG#v}"
-          echo "version=${VERSION_TRIMMED}" >> "$GITHUB_OUTPUT"
-      - name: Clone tap repository
+          ref: ${{ github.event.inputs.tag_name }}
+      - name: Update tap formula
         env:
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${TAP_TOKEN:-}" ]]; then
-            echo "HOMEBREW_TAP secret not set. Add a fine-grained PAT with 'Contents: Read and write' on taihen/homebrew-tap." >&2
-            exit 1
-          fi
-          git clone "https://x-access-token:${TAP_TOKEN}@github.com/taihen/homebrew-tap.git" tap
-      - name: Ensure formula exists and update fields
-        shell: bash
-        run: |
-          set -euo pipefail
-          FORMULA_NAME="dns-benchmark"
-          mkdir -p tap/Formula
-
-          # Prefer local formula if present; else fall back to existing in tap
-          if [[ -f "Formula/${FORMULA_NAME}.rb" ]]; then
-            cp "Formula/${FORMULA_NAME}.rb" "tap/Formula/${FORMULA_NAME}.rb"
-          elif [[ ! -f "tap/Formula/${FORMULA_NAME}.rb" ]]; then
-            echo "Formula/${FORMULA_NAME}.rb not found locally or in tap. Seed the tap with an initial formula." >&2
-            exit 1
-          fi
-          URL="${{ steps.artifact.outputs.url }}"
-          SHA256="${{ steps.artifact.outputs.sha256 }}"
-          VERSION_TRIMMED="${{ steps.artifact.outputs.version }}"
-
-          # Update url and sha256 lines; update version if present
-          sed -i.bak -E \
-            -e "s|^(\\s*url\\s+\").*\"|\\1${URL}\"|" \
-            -e "s|^(\\s*sha256\\s+\").*\"|\\1${SHA256}\"|" \
-            -e "s|^(\\s*version\\s+\").*\"|\\1${VERSION_TRIMMED}\"|" \
-            "tap/Formula/${FORMULA_NAME}.rb" || true
-          rm -f "tap/Formula/${FORMULA_NAME}.rb.bak"
-          echo "Preview of updated fields:"
-          grep -nE '^(\s*url|\s*sha256|\s*version)' "tap/Formula/${FORMULA_NAME}.rb" || true
-      - name: Commit and push to tap
-        env:
-          GIT_AUTHOR_NAME: dns-benchmark-bot
-          GIT_AUTHOR_EMAIL: dns-benchmark@users.noreply.github.com
-          GIT_COMMITTER_NAME: dns-benchmark-bot
-          GIT_COMMITTER_EMAIL: dns-benchmark@users.noreply.github.com
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP }}
-        shell: bash
-        run: |-
-          set -euo pipefail
-          cd tap
-          git config user.name "$GIT_AUTHOR_NAME"
-          git config user.email "$GIT_AUTHOR_EMAIL"
-          git add Formula/dns-benchmark.rb
-          if git diff --cached --quiet; then
-            echo "No changes to commit."
-            exit 0
-          fi
-          TAG="${{ github.event.release.tag_name || github.event.inputs.tag_name }}"
-          git commit -m "dns-benchmark ${TAG}: update formula url and sha256"
-          git push origin HEAD:main
+        run: bash ./scripts/update-homebrew-formula.sh

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@
 
 ```bash
 # Add Homebrew tap
-brew tap taihen/dns-benchmark
+brew tap taihen/tap
+
+# Install dns-benchmark
+brew install taihen/tap/dns-benchmark
 
 # Update to latest version
-brew install taihen/tap/dns-benchmark
+brew update
+brew upgrade taihen/tap/dns-benchmark
 ```
 
 ### Manual Installation

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,71 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Script to automatically update Homebrew formula for dns-benchmark
-# This should be run after each release
+set -euo pipefail
 
-set -e
-
-# Configuration
-REPO="taihen/dns-benchmark"
 FORMULA_NAME="dns-benchmark"
+TAP_REPO="taihen/homebrew-tap"
+TAG_NAME="${TAG_NAME:-${1:-}}"
+TAP_TOKEN="${TAP_TOKEN:-}"
+REPO="${GITHUB_REPOSITORY:-taihen/dns-benchmark}"
 
-# Get the latest release version
-LATEST_VERSION=$(gh release list --repo $REPO --limit 1 --json tagName --jq '.[0].tagName' | sed 's/v//')
-
-if [ -z "$LATEST_VERSION" ]; then
-    echo "Error: Could not get latest release version"
-    exit 1
+if [[ -z "${TAG_NAME}" ]]; then
+  echo "TAG_NAME is required" >&2
+  exit 1
 fi
 
-echo "Latest version: $LATEST_VERSION"
+if [[ -z "${TAP_TOKEN}" ]]; then
+  echo "TAP_TOKEN is required" >&2
+  exit 1
+fi
 
-# Download the release assets to get SHA256 checksums
-TEMP_DIR=$(mktemp -d)
-cd "$TEMP_DIR"
+OWNER="${REPO%/*}"
+REPO_NAME="${REPO#*/}"
+URL="https://github.com/${OWNER}/${REPO_NAME}/archive/refs/tags/${TAG_NAME}.tar.gz"
+SHA256="$(curl -fsSL "${URL}" | shasum -a 256 | awk '{print $1}')"
+VERSION_TRIMMED="${TAG_NAME#v}"
 
-# Download macOS binaries
-gh release download --repo $REPO --pattern "dns-benchmark-darwin-*" --dir "$TEMP_DIR"
+work_dir="$(mktemp -d)"
+tap_dir="${work_dir}/tap"
 
-# Calculate SHA256 checksums
-ARM64_SHA=$(shasum -a 256 dns-benchmark-darwin-arm64 | cut -d' ' -f1)
-AMD64_SHA=$(shasum -a 256 dns-benchmark-darwin-amd64 | cut -d' ' -f1)
+cleanup() {
+  rm -rf "${work_dir}"
+}
 
-echo "ARM64 SHA256: $ARM64_SHA"
-echo "AMD64 SHA256: $AMD64_SHA"
+trap cleanup EXIT
 
-# Create the updated formula
-cat > "${FORMULA_NAME}.rb" << FORMULA_EOF
-class DnsBenchmark < Formula
-  desc "DNS benchmark tool that tests DNS resolver performance across multiple protocols"
-  homepage "https://github.com/taihen/dns-benchmark"
-  url "https://github.com/taihen/dns-benchmark/releases/download/v${LATEST_VERSION}/dns-benchmark-darwin-arm64"
-  sha256 "${ARM64_SHA}"
-  license "MIT"
-  head "https://github.com/taihen/dns-benchmark.git", branch: "main"
+git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" "${tap_dir}"
+mkdir -p "${tap_dir}/Formula"
 
-  on_intel do
-    url "https://github.com/taihen/dns-benchmark/releases/download/v${LATEST_VERSION}/dns-benchmark-darwin-amd64"
-    sha256 "${AMD64_SHA}"
-  end
+# Prefer a local formula template when one exists in this repo.
+if [[ -f "Formula/${FORMULA_NAME}.rb" ]]; then
+  cp "Formula/${FORMULA_NAME}.rb" "${tap_dir}/Formula/${FORMULA_NAME}.rb"
+elif [[ ! -f "${tap_dir}/Formula/${FORMULA_NAME}.rb" ]]; then
+  echo "Formula/${FORMULA_NAME}.rb not found locally or in ${TAP_REPO}" >&2
+  exit 1
+fi
 
-  def install
-    # Install the binary directly from the release
-    bin.install "dns-benchmark-darwin-\#{Hardware::CPU.arch}" => "dns-benchmark"
-  end
+sed -i.bak -E \
+  -e "s|^(\\s*url\\s+\").*\"|\\1${URL}\"|" \
+  -e "s|^(\\s*sha256\\s+\").*\"|\\1${SHA256}\"|" \
+  -e "s|^(\\s*version\\s+\").*\"|\\1${VERSION_TRIMMED}\"|" \
+  "${tap_dir}/Formula/${FORMULA_NAME}.rb" || true
+rm -f "${tap_dir}/Formula/${FORMULA_NAME}.rb.bak"
 
-  test do
-    # Test that the binary runs and shows version
-    assert_match "dns-benchmark", shell_output("\#{bin}/dns-benchmark --version")
-  end
-end
-FORMULA_EOF
+cd "${tap_dir}"
+git add "Formula/${FORMULA_NAME}.rb"
 
-echo "Updated formula created: ${FORMULA_NAME}.rb"
-echo "Next steps:"
-echo "1. Create Formula directory in your repository: mkdir -p Formula"
-echo "2. Copy this formula: cp ${FORMULA_NAME}.rb Formula/"
-echo "3. Commit and push the changes"
+if git diff --cached --quiet; then
+  echo "No changes to commit."
+  exit 0
+fi
 
-# Clean up
-cd - > /dev/null
-rm -rf "$TEMP_DIR"
+GIT_AUTHOR_NAME="dns-benchmark-bot" \
+GIT_AUTHOR_EMAIL="dns-benchmark@users.noreply.github.com" \
+GIT_COMMITTER_NAME="dns-benchmark-bot" \
+GIT_COMMITTER_EMAIL="dns-benchmark@users.noreply.github.com" \
+git commit -m "${FORMULA_NAME} ${TAG_NAME}: update formula url and sha256"
+git push origin HEAD:main


### PR DESCRIPTION
This fixes Homebrew updates not picking up new releases.
The release workflow now updates the Homebrew tap directly after `semantic-release` publishes a new tag, instead of relying on a separate `release.published` workflow that GitHub does not trigger when the release is created with `GITHUB_TOKEN`.
It also cleans up the manual tap update workflow to reuse the same script and corrects the README Homebrew instructions to use the real tap name and `brew upgrade` for updates.
